### PR TITLE
add version strings for NC 10.2 and 11

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,6 +12,7 @@
    <repository type="git">https://github.com/v1r0x/polls.git</repository>
    <dependencies>
       <owncloud min-version="8.1" max-version="9.1"/>
+      <nextcloud min-version="9.1" max-version="11" />
    </dependencies>
    <ocsid>174671</ocsid>
 </info>


### PR DESCRIPTION
add nextcloud version info - tests with 11 went ok; 10.2 ongoing and
look good.