### PR TITLE
append counter to text polls

### DIFF
--- a/controller/pagecontroller.php
+++ b/controller/pagecontroller.php
@@ -351,11 +351,13 @@ class PageController extends Controller {
             $event->setType(1);
             $ins = $this->eventMapper->insert($event);
             $poll_id = $ins->getId();
+            $cnt = 1;
             foreach($chosenDates as $el) {
                 $text = new Text();
-                $text->setText($el);
+                $text->setText($el . '_' . $cnt);
                 $text->setPollId($poll_id);
                 $this->textMapper->insert($text);
+                $cnt++;
             }
         }
         $url = $this->urlGenerator->linkToRoute('polls.page.index');

--- a/templates/goto.tmpl.php
+++ b/templates/goto.tmpl.php
@@ -88,7 +88,7 @@ $pollUrl = $urlGenerator->linkToRouteAbsolute('polls.page.goto_poll', ['hash' =>
                                     } else {
                                         print_unescaped('<th></th>');
                                         foreach ($dates as $el) {
-                                            print_unescaped('<th title="' . $el->getText(). '" class="bordered">' . $el->getText() . '</th>');
+                                            print_unescaped('<th title="' . preg_replace('/_\d+$/', '', $el->getText()) . '" class="bordered">' . preg_replace('/_\d+$/', '', $el->getText()) . '</th>');
                                         }
                                         print_unescaped('<th class="bordered">' . $l->t('All') . '</th>');
                                     }
@@ -297,7 +297,7 @@ $pollUrl = $urlGenerator->linkToRouteAbsolute('polls.page.goto_poll', ['hash' =>
                                     } else {
                                         print_unescaped('<th></th>');
                                         foreach ($dates as $el) {
-                                            print_unescaped('<th title="' . $el->getText() . '" class="bordered">' . $el->getText() . '</th>');
+                                            print_unescaped('<th title="' . preg_replace('/_\d+$/', '', $el->getText()) . '" class="bordered">' . preg_replace('/_\d+$/', '', $el->getText()) . '</th>');
                                         }
                                         print_unescaped('<th class="bordered"></th>');
                                     }


### PR DESCRIPTION
Fix #114 

This PR appends a counter to text poll entries. Thus there are no double values in the database (e.g. `tea_0`, `cake_1`, `tea_2`, ...). This doesn't work for existing polls, only for new polls. Hope this helps anyway. Please test @joergmschulz 